### PR TITLE
feat: elasticsearch 초기 설정 및 인덱스,Document 생성

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,6 +20,20 @@ services:
       retries: 10
       start_period: 30s
 
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.19.10
+    container_name: inventory-kibana
+    ports:
+      - "5601:5601"
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    networks:
+      - inventory-net
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    restart: unless-stopped
+
   backend:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,23 @@ services:
       retries: 10
       start_period: 30s
 
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.19.10
+    container_name: kibana
+    ports:
+      - "5601:5601"
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:5601/api/status >/dev/null || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+
   backend:
     build:
       context: .

--- a/src/main/java/kr/inventory/domain/analytics/constant/ElasticsearchIndex.java
+++ b/src/main/java/kr/inventory/domain/analytics/constant/ElasticsearchIndex.java
@@ -1,0 +1,13 @@
+package kr.inventory.domain.analytics.constant;
+
+// Elasticsearch 인덱스명 상수
+public final class ElasticsearchIndex {
+
+    public static final String SALES_ORDERS = "sales_orders";
+    public static final String STOCK_INBOUNDS = "stock_inbounds";
+    public static final String STOCK_LOGS = "stock_logs";
+    public static final String WASTE_RECORDS = "waste_records";
+
+    private ElasticsearchIndex() {
+    }
+}

--- a/src/main/java/kr/inventory/domain/analytics/document/sales/SalesOrderDocument.java
+++ b/src/main/java/kr/inventory/domain/analytics/document/sales/SalesOrderDocument.java
@@ -1,0 +1,62 @@
+package kr.inventory.domain.analytics.document.sales;
+
+import kr.inventory.domain.analytics.constant.ElasticsearchIndex;
+import kr.inventory.domain.sales.entity.SalesOrder;
+import kr.inventory.domain.sales.entity.SalesOrderItem;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Document(indexName = ElasticsearchIndex.SALES_ORDERS)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SalesOrderDocument {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Long)
+    private Long storeId;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    private OffsetDateTime orderedAt;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    private OffsetDateTime completedAt;
+
+    @Field(type = FieldType.Double)
+    private BigDecimal totalAmount;
+
+    @Field(type = FieldType.Keyword)
+    private String status;
+
+    @Field(type = FieldType.Keyword)
+    private String orderType;
+
+    @Field(type = FieldType.Nested)
+    private List<SalesOrderItemDocument> items;
+
+    public static SalesOrderDocument from(SalesOrder order, List<SalesOrderItem> items) {
+        SalesOrderDocument doc = new SalesOrderDocument();
+        doc.id = String.valueOf(order.getSalesOrderId());
+        doc.storeId = order.getStore().getStoreId();
+        doc.orderedAt = order.getOrderedAt();
+        doc.completedAt = order.getCompletedAt();
+        doc.totalAmount = order.getTotalAmount();
+        doc.status = order.getStatus().name();
+        doc.orderType = order.getType().name();
+        doc.items = items.stream()
+                .map(SalesOrderItemDocument::from)
+                .toList();
+        return doc;
+    }
+}

--- a/src/main/java/kr/inventory/domain/analytics/document/sales/SalesOrderItemDocument.java
+++ b/src/main/java/kr/inventory/domain/analytics/document/sales/SalesOrderItemDocument.java
@@ -1,0 +1,37 @@
+package kr.inventory.domain.analytics.document.sales;
+
+import kr.inventory.domain.sales.entity.SalesOrderItem;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.math.BigDecimal;
+
+// @Document 없음: 독립 인덱스가 아닌 sales_orders 내부에 중첩
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SalesOrderItemDocument {
+
+    @Field(type = FieldType.Keyword)
+    private String menuName;
+
+    @Field(type = FieldType.Double)
+    private BigDecimal price;
+
+    @Field(type = FieldType.Integer)
+    private Integer quantity;
+
+    @Field(type = FieldType.Double)
+    private BigDecimal subtotal;
+
+    public static SalesOrderItemDocument from(SalesOrderItem item) {
+        SalesOrderItemDocument doc = new SalesOrderItemDocument();
+        doc.menuName = item.getMenuName();
+        doc.price = item.getPrice();
+        doc.quantity = item.getQuantity();
+        doc.subtotal = item.getSubtotal();
+        return doc;
+    }
+}

--- a/src/main/java/kr/inventory/domain/analytics/document/stock/StockInboundDocument.java
+++ b/src/main/java/kr/inventory/domain/analytics/document/stock/StockInboundDocument.java
@@ -1,0 +1,52 @@
+package kr.inventory.domain.analytics.document.stock;
+
+import kr.inventory.domain.analytics.constant.ElasticsearchIndex;
+import kr.inventory.domain.stock.entity.StockInbound;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+@Document(indexName = ElasticsearchIndex.STOCK_INBOUNDS)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockInboundDocument {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Long)
+    private Long storeId;
+
+    @Field(type = FieldType.Keyword)
+    private String vendorName;
+
+    @Field(type = FieldType.Date, format = DateFormat.date)
+    private LocalDate inboundDate;
+
+    @Field(type = FieldType.Keyword)
+    private String status;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    private OffsetDateTime confirmedAt;
+
+    public static StockInboundDocument from(StockInbound inbound) {
+        StockInboundDocument doc = new StockInboundDocument();
+        doc.id = String.valueOf(inbound.getInboundId());
+        doc.storeId = inbound.getStore().getStoreId();
+        doc.vendorName = inbound.getVendor() != null
+                ? inbound.getVendor().getName()
+                : null;
+        doc.inboundDate = inbound.getInboundDate();
+        doc.status = inbound.getStatus().name();
+        doc.confirmedAt = inbound.getConfirmedAt();
+        return doc;
+    }
+}

--- a/src/main/java/kr/inventory/domain/analytics/document/stock/StockLogDocument.java
+++ b/src/main/java/kr/inventory/domain/analytics/document/stock/StockLogDocument.java
@@ -1,0 +1,64 @@
+package kr.inventory.domain.analytics.document.stock;
+
+import kr.inventory.domain.analytics.constant.ElasticsearchIndex;
+import kr.inventory.domain.stock.entity.StockLog;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Document(indexName = ElasticsearchIndex.STOCK_LOGS)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockLogDocument {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Long)
+    private Long storeId;
+
+    @Field(type = FieldType.Long)
+    private Long ingredientId;
+
+    @Field(type = FieldType.Keyword)
+    private String ingredientName;
+
+    @Field(type = FieldType.Keyword)
+    private String transactionType;
+
+    @Field(type = FieldType.Keyword)
+    private String referenceType;
+
+    @Field(type = FieldType.Double)
+    private BigDecimal changeQuantity;
+
+    @Field(type = FieldType.Double)
+    private BigDecimal balanceAfter;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    private OffsetDateTime createdAt;
+
+    public static StockLogDocument from(StockLog stockLog) {
+        StockLogDocument doc = new StockLogDocument();
+        doc.id = String.valueOf(stockLog.getLogId());
+        doc.storeId = stockLog.getStore().getStoreId();
+        doc.ingredientId = stockLog.getIngredient().getIngredientId();
+        doc.ingredientName = stockLog.getIngredient().getName();
+        doc.transactionType = stockLog.getTransactionType().name();
+        doc.referenceType = stockLog.getReferenceType() != null
+                ? stockLog.getReferenceType().name()
+                : null;
+        doc.changeQuantity = stockLog.getChangeQuantity();
+        doc.balanceAfter = stockLog.getBalanceAfter();
+        doc.createdAt = stockLog.getCreatedAt();
+        return doc;
+    }
+}

--- a/src/main/java/kr/inventory/domain/analytics/document/stock/WasteRecordDocument.java
+++ b/src/main/java/kr/inventory/domain/analytics/document/stock/WasteRecordDocument.java
@@ -1,0 +1,58 @@
+package kr.inventory.domain.analytics.document.stock;
+
+import kr.inventory.domain.analytics.constant.ElasticsearchIndex;
+import kr.inventory.domain.stock.entity.WasteRecord;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Document(indexName = ElasticsearchIndex.WASTE_RECORDS)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WasteRecordDocument {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Long)
+    private Long storeId;
+
+    @Field(type = FieldType.Long)
+    private Long ingredientId;
+
+    @Field(type = FieldType.Keyword)
+    private String ingredientName;
+
+    @Field(type = FieldType.Double)
+    private BigDecimal wasteQuantity;
+
+    @Field(type = FieldType.Keyword)
+    private String wasteReason;
+
+    @Field(type = FieldType.Double)
+    private BigDecimal wasteAmount;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    private OffsetDateTime wasteDate;
+
+    public static WasteRecordDocument from(WasteRecord wasteRecord) {
+        WasteRecordDocument doc = new WasteRecordDocument();
+        doc.id = String.valueOf(wasteRecord.getWasteId());
+        doc.storeId = wasteRecord.getStore().getStoreId();
+        doc.ingredientId = wasteRecord.getIngredient().getIngredientId();
+        doc.ingredientName = wasteRecord.getIngredient().getName();
+        doc.wasteQuantity = wasteRecord.getWasteQuantity();
+        doc.wasteReason = wasteRecord.getWasteReason().name();
+        doc.wasteAmount = wasteRecord.getWasteAmount();
+        doc.wasteDate = wasteRecord.getWasteDate();
+        return doc;
+    }
+}

--- a/src/main/java/kr/inventory/global/config/ElasticsearchConfig.java
+++ b/src/main/java/kr/inventory/global/config/ElasticsearchConfig.java
@@ -1,0 +1,25 @@
+package kr.inventory.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories(basePackages = "kr.inventory.domain.analytics.repository")
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+    @Value("${spring.elasticsearch.uris}")
+    private String elasticsearchUri;
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        String host = elasticsearchUri
+                .replace("https://", "")
+                .replace("http://", "");
+
+        return ClientConfiguration.builder()
+                .connectedTo(host)
+                .build();
+    }
+}


### PR DESCRIPTION
## 이슈 번호
- Closes #132

## 작업 내용
- ElasticsearchConfig 설정 클래스 추가 (컨테이너 환경 대응, ${ES_URL} 환경변수 기반 연결)
- ES 인덱스명 상수 클래스 ElasticsearchIndex 추가
- Document 클래스 4개 추가 
 -SalesOrderDocument, SalesOrderItemDocument, StockInboundDocument, StockLogDocument, WasteRecordDocument
- docker-compose.yml, docker-compose.prod.yml에 Kibana 8.19.10 서비스 추가