### PR TITLE
fix: 매출 분석 Redis 캐싱 전략 개선 - 실시간 데이터 반영 문제 해결

### DIFF
--- a/src/main/java/kr/inventory/domain/analytics/service/SalesAnalyticsService.java
+++ b/src/main/java/kr/inventory/domain/analytics/service/SalesAnalyticsService.java
@@ -31,15 +31,11 @@ public class SalesAnalyticsService {
 
     /**
      * 일/주/월 매출 추이
-     * TTL: RedisConfig 기본값 30분
-     * 조건부 캐싱: 조회 종료일이 오늘 00:00 이전(= 어제까지)인 경우만 캐싱
-     * - 과거 기간 조회: 캐싱 O (데이터 불변, 성능 최적화)
-     * - 오늘 포함 조회: 캐싱 X (실시간 데이터 반영)
      */
     @Cacheable(
             value = "sales:trend",
             key = "#storePublicId + ':' + #from.toInstant().toEpochMilli() + ':' + #to.toInstant().toEpochMilli() + ':' + #interval",
-            condition = "#to.isBefore(T(java.time.OffsetDateTime).now().withHour(0).withMinute(0).withSecond(0).withNano(0))"
+            condition = "#to != null && #to.isBefore(T(java.time.OffsetDateTime).now().withHour(0).withMinute(0).withSecond(0).withNano(0))"
     )
     public List<SalesTrendResponse> getSalesTrend(
             Long userId,
@@ -64,15 +60,11 @@ public class SalesAnalyticsService {
 
     /**
      * 요일×시간대 피크
-     * TTL: RedisConfig 기본값 30분
-     * 조건부 캐싱: 조회 종료일이 오늘 00:00 이전(= 어제까지)인 경우만 캐싱
-     * - 과거 기간 조회: 캐싱 O (피크 패턴 불변, 성능 최적화)
-     * - 오늘 포함 조회: 캐싱 X (실시간 데이터 반영)
      */
     @Cacheable(
             value = "sales:peak",
             key = "#storePublicId + ':' + #from.toInstant().toEpochMilli() + ':' + #to.toInstant().toEpochMilli()",
-            condition = "#to.isBefore(T(java.time.OffsetDateTime).now().withHour(0).withMinute(0).withSecond(0).withNano(0))"
+            condition = "#to != null && #to.isBefore(T(java.time.OffsetDateTime).now().withHour(0).withMinute(0).withSecond(0).withNano(0))"
     )
     public List<SalesPeakResponse> getSalesPeak(
             Long userId,
@@ -95,15 +87,11 @@ public class SalesAnalyticsService {
 
     /**
      * 메뉴 TOP N
-     * TTL: 30분
-     * 조건부 캐싱: 조회 종료일이 오늘 00:00 이전(= 어제까지)인 경우만 캐싱
-     * - 과거 기간 조회: 캐싱 O (메뉴 랭킹 불변, 성능 최적화)
-     * - 오늘 포함 조회: 캐싱 X (실시간 데이터 반영)
      */
     @Cacheable(
             value = "sales:menu-ranking",
             key = "#storePublicId + ':' + #from.toInstant().toEpochMilli() + ':' + #to.toInstant().toEpochMilli() + ':' + #topN",
-            condition = "#to.isBefore(T(java.time.OffsetDateTime).now().withHour(0).withMinute(0).withSecond(0).withNano(0))"
+            condition = "#to != null && #to.isBefore(T(java.time.OffsetDateTime).now().withHour(0).withMinute(0).withSecond(0).withNano(0))"
     )
     public List<MenuRankingResponse> getMenuRanking(
             Long userId,
@@ -129,15 +117,11 @@ public class SalesAnalyticsService {
 
     /**
      * 매출 요약 (객단가 등)
-     * TTL: 30분
-     * 조건부 캐싱: 조회 종료일이 오늘 00:00 이전(= 어제까지)인 경우만 캐싱
-     * - 과거 기간 조회: 캐싱 O (요약 데이터 불변, 성능 최적화)
-     * - 오늘 포함 조회: 캐싱 X (실시간 데이터 반영)
      */
     @Cacheable(
             value = "sales:summary",
             key = "#storePublicId + ':' + #from.toInstant().toEpochMilli() + ':' + #to.toInstant().toEpochMilli() + ':' + #interval",
-            condition = "#to.isBefore(T(java.time.OffsetDateTime).now().withHour(0).withMinute(0).withSecond(0).withNano(0))"
+            condition = "#to != null && #to.isBefore(T(java.time.OffsetDateTime).now().withHour(0).withMinute(0).withSecond(0).withNano(0))"
     )
     public SalesSummaryResponse getSalesSummary(
             Long userId,
@@ -205,10 +189,6 @@ public class SalesAnalyticsService {
                 .multiply(BigDecimal.valueOf(100))
                 .doubleValue();
     }
-
-    // ────────────────────────────────────────────────────────
-    // Private Helper Methods
-    // ────────────────────────────────────────────────────────
 
     /**
      * interval 정규화 (소문자 → 대문자 첫글자)

--- a/src/test/java/kr/inventory/domain/analytics/service/CacheConditionValidationTest.java
+++ b/src/test/java/kr/inventory/domain/analytics/service/CacheConditionValidationTest.java
@@ -1,0 +1,94 @@
+package kr.inventory.domain.analytics.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @Cacheable condition에 사용되는 SpEL 표현식 검증 테스트
+ *
+ * 목적: 조건부 캐싱이 정상 작동하는지 SpEL 파싱 레벨에서 검증
+ */
+@DisplayName("캐시 조건 SpEL 표현식 검증 테스트")
+class CacheConditionValidationTest {
+
+    private final ExpressionParser parser = new SpelExpressionParser();
+
+    @Test
+    @DisplayName("과거 날짜는 캐싱 조건을 만족해야 한다")
+    void givenPastDate_whenEvaluateCondition_thenShouldCache() {
+        // Given
+        OffsetDateTime pastDate = OffsetDateTime.now().minusDays(1);
+
+        // When
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        context.setVariable("to", pastDate);
+
+        Boolean result = parser.parseExpression(
+            "#to != null && #to.isBefore(T(java.time.OffsetDateTime).now().withHour(0).withMinute(0).withSecond(0).withNano(0))"
+        ).getValue(context, Boolean.class);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("오늘 날짜는 캐싱 조건을 만족하지 않아야 한다")
+    void givenTodayDate_whenEvaluateCondition_thenShouldNotCache() {
+        // Given
+        OffsetDateTime today = OffsetDateTime.now();
+
+        // When
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        context.setVariable("to", today);
+
+        Boolean result = parser.parseExpression(
+            "#to != null && #to.isBefore(T(java.time.OffsetDateTime).now().withHour(0).withMinute(0).withSecond(0).withNano(0))"
+        ).getValue(context, Boolean.class);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("null 값은 NPE 없이 false를 반환해야 한다")
+    void givenNullDate_whenEvaluateCondition_thenShouldReturnFalseWithoutNPE() {
+        // Given
+        OffsetDateTime nullDate = null;
+
+        // When
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        context.setVariable("to", nullDate);
+
+        Boolean result = parser.parseExpression(
+            "#to != null && #to.isBefore(T(java.time.OffsetDateTime).now().withHour(0).withMinute(0).withSecond(0).withNano(0))"
+        ).getValue(context, Boolean.class);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("미래 날짜는 캐싱 조건을 만족하지 않아야 한다")
+    void givenFutureDate_whenEvaluateCondition_thenShouldNotCache() {
+        // Given
+        OffsetDateTime futureDate = OffsetDateTime.now().plusDays(1);
+
+        // When
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        context.setVariable("to", futureDate);
+
+        Boolean result = parser.parseExpression(
+            "#to != null && #to.isBefore(T(java.time.OffsetDateTime).now().withHour(0).withMinute(0).withSecond(0).withNano(0))"
+        ).getValue(context, Boolean.class);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/kr/inventory/domain/analytics/service/SalesAnalyticsServiceTest.java
+++ b/src/test/java/kr/inventory/domain/analytics/service/SalesAnalyticsServiceTest.java
@@ -52,8 +52,8 @@ class SalesAnalyticsServiceTest {
         Long userId = 100L;
         Long storeId = 1L;
         UUID storePublicId = UUID.randomUUID();
-        OffsetDateTime from = OffsetDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        OffsetDateTime to = OffsetDateTime.of(2025, 1, 31, 23, 59, 59, 0, ZoneOffset.UTC);
+        OffsetDateTime from = OffsetDateTime.now(ZoneOffset.UTC).minusDays(31);
+        OffsetDateTime to = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
 
         List<SalesTrendResponse> expected = List.of(
                 new SalesTrendResponse("2025-01-01", 5L, new BigDecimal("120000.00"))
@@ -74,8 +74,8 @@ class SalesAnalyticsServiceTest {
         Long userId = 100L;
         Long storeId = 1L;
         UUID storePublicId = UUID.randomUUID();
-        OffsetDateTime from = OffsetDateTime.of(2025, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        OffsetDateTime to = OffsetDateTime.of(2025, 2, 7, 23, 59, 59, 0, ZoneOffset.UTC);
+        OffsetDateTime from = OffsetDateTime.now(ZoneOffset.UTC).minusDays(7);
+        OffsetDateTime to = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
 
         given(storeAccessValidator.validateAndGetStoreId(userId, storePublicId)).willReturn(storeId);
         given(salesOrderSearchRepository.aggregateSalesTrend(storeId, from, to, "Day")).willReturn(List.of());
@@ -90,8 +90,8 @@ class SalesAnalyticsServiceTest {
     void givenInvalidInterval_whenGetSalesTrend_thenThrowException() {
         Long userId = 100L;
         UUID storePublicId = UUID.randomUUID();
-        OffsetDateTime from = OffsetDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        OffsetDateTime to = OffsetDateTime.of(2025, 1, 10, 23, 59, 59, 0, ZoneOffset.UTC);
+        OffsetDateTime from = OffsetDateTime.now(ZoneOffset.UTC).minusDays(10);
+        OffsetDateTime to = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
 
         assertThatThrownBy(() -> salesAnalyticsService.getSalesTrend(userId, storePublicId, from, to, "year"))
                 .isInstanceOf(AnalyticsException.class)
@@ -106,8 +106,8 @@ class SalesAnalyticsServiceTest {
         Long storeId = 1L;
         UUID storePublicId = UUID.randomUUID();
 
-        OffsetDateTime from = OffsetDateTime.of(2025, 3, 10, 0, 0, 0, 0, ZoneOffset.UTC);
-        OffsetDateTime to = OffsetDateTime.of(2025, 3, 16, 23, 59, 59, 0, ZoneOffset.UTC);
+        OffsetDateTime from = OffsetDateTime.now(ZoneOffset.UTC).minusDays(14);
+        OffsetDateTime to = OffsetDateTime.now(ZoneOffset.UTC).minusDays(8);
 
         SalesSummaryResponse current = new SalesSummaryResponse(
                 20L,
@@ -150,8 +150,8 @@ class SalesAnalyticsServiceTest {
         Long storeId = 1L;
         UUID storePublicId = UUID.randomUUID();
 
-        OffsetDateTime from = OffsetDateTime.of(2025, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        OffsetDateTime to = OffsetDateTime.of(2025, 2, 28, 23, 59, 59, 0, ZoneOffset.UTC);
+        OffsetDateTime from = OffsetDateTime.now(ZoneOffset.UTC).minusDays(60);
+        OffsetDateTime to = OffsetDateTime.now(ZoneOffset.UTC).minusDays(32);
 
         SalesSummaryResponse current = new SalesSummaryResponse(1L, BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ONE,
                 null, null, null, null);
@@ -196,8 +196,8 @@ class SalesAnalyticsServiceTest {
         Long storeId = 1L;
         UUID storePublicId = UUID.randomUUID();
 
-        OffsetDateTime from = OffsetDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        OffsetDateTime to = OffsetDateTime.of(2025, 1, 10, 23, 59, 59, 0, ZoneOffset.UTC);
+        OffsetDateTime from = OffsetDateTime.now(ZoneOffset.UTC).minusDays(10);
+        OffsetDateTime to = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
 
         given(storeAccessValidator.validateAndGetStoreId(userId, storePublicId)).willReturn(storeId);
         given(salesOrderSearchRepository.aggregateMenuRanking(eq(storeId), eq(from), eq(to), eq(10))).willReturn(List.of());


### PR DESCRIPTION
## 이슈 번호
- Closes #175

## 작업 내용
  - `SalesAnalyticsService`의 4개 메서드에 조건부 캐싱 적용
    - `getSalesTrend()`: 매출 추이 조회
    - `getSalesPeak()`: 요일×시간대 피크 조회
    - `getMenuRanking()`: 메뉴 TOP N 조회
    - `getSalesSummary()`: 매출 요약 조회
  - `@Cacheable`의 `condition` 속성 추가: 조회 종료일이 어제 이전인 경우만 캐싱
  - 과거 기간 조회: 30분 캐싱 유지 (성능 최적화)
  - 현재 진행 중인 기간 조회: 캐시 비활성화 (실시간 데이터)
