### PR TITLE
feat: WebSocket STOMP 인증 처리 기능 추가

### DIFF
--- a/src/main/java/kr/inventory/Application.java
+++ b/src/main/java/kr/inventory/Application.java
@@ -2,8 +2,10 @@ package kr.inventory;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-//TEST
+import org.springframework.scheduling.annotation.EnableScheduling;
+
 @SpringBootApplication
+@EnableScheduling
 public class Application {
 
     public static void main(String[] args) {

--- a/src/main/java/kr/inventory/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/kr/inventory/domain/auth/exception/AuthErrorCode.java
@@ -15,7 +15,9 @@ public enum AuthErrorCode implements ErrorModel {
     LOGOUT_TOKEN(HttpStatus.UNAUTHORIZED, "A005", "이미 로그아웃 처리된 토큰입니다. 다시 로그인해주세요."),
     INVALID_AUTH_CODE(HttpStatus.UNAUTHORIZED, "A006", "유효하지 않은 코드입니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "A007", "유효하지 않은 토큰입니다."),
-    INVALID_TOKEN_FORMAT(HttpStatus.BAD_REQUEST, "A008", "유효하지 않은 토큰 형식입니다.");
+    INVALID_TOKEN_FORMAT(HttpStatus.BAD_REQUEST, "A008", "유효하지 않은 토큰 형식입니다."),
+    USER_INFO_NOT_FOUND(HttpStatus.UNAUTHORIZED, "A009", "인증된 사용자 정보를 찾을 수 없습니다."),
+    INVALID_USER_ID_FORMAT(HttpStatus.BAD_REQUEST, "A010", "사용자 식별자를 해석할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kr/inventory/domain/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/kr/inventory/domain/chat/controller/ChatWebSocketController.java
@@ -1,15 +1,15 @@
 package kr.inventory.domain.chat.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import kr.inventory.domain.auth.security.CustomUserDetails;
+import java.security.Principal;
 import kr.inventory.domain.chat.controller.dto.request.ChatSendMessageRequest;
 import kr.inventory.domain.chat.service.ChatCommandService;
+import kr.inventory.global.auth.util.PrincipalUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 @Controller
 @RequiredArgsConstructor
@@ -20,11 +20,11 @@ public class ChatWebSocketController {
     @Operation(summary = "채팅 메시지 전송")
     @MessageMapping("/chat.send")
     public void send(
-            @Valid ChatSendMessageRequest request,
-            @AuthenticationPrincipal CustomUserDetails principal
+            @Payload @Valid ChatSendMessageRequest request,
+            Principal principal
     ) {
         chatCommandService.acceptUserMessage(
-                principal.getUserId(),
+                PrincipalUtils.extractUserId(principal),
                 request.threadId(),
                 request.clientMessageId(),
                 request.content()

--- a/src/main/java/kr/inventory/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/inventory/global/auth/filter/JwtAuthenticationFilter.java
@@ -59,9 +59,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String resolveToken(HttpServletRequest request) {
+        // Authorization 헤더에서 토큰 추출
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(BEARER_PREFIX_LENGTH);
+        }
+        // 쿼리 파라미터에서 토큰 추출
+        String tokenParam = request.getParameter("token");
+        if (StringUtils.hasText(tokenParam)) {
+            return tokenParam;
         }
         return null;
     }

--- a/src/main/java/kr/inventory/global/auth/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/kr/inventory/global/auth/interceptor/StompAuthChannelInterceptor.java
@@ -1,0 +1,112 @@
+package kr.inventory.global.auth.interceptor;
+
+import kr.inventory.domain.auth.constant.AuthConstant;
+import kr.inventory.global.auth.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String AUTHORIZATION_HEADER_LOWER_CASE = "authorization";
+    private static final String TOKEN_HEADER = "token";
+    private static final String ACCESS_TOKEN_HEADER = "accessToken";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null) {
+            return message;
+        }
+
+        StompCommand command = accessor.getCommand();
+        if (command == null) {
+            return message;
+        }
+
+        if (!requiresAuthentication(command) || accessor.getUser() != null) {
+            return message;
+        }
+
+        String accessToken = resolveToken(accessor);
+        if (!StringUtils.hasText(accessToken)) {
+            return message;
+        }
+
+        if (!jwtProvider.validateToken(accessToken)) {
+            log.warn("Ignoring STOMP frame with invalid token. sessionId={}, command={}", accessor.getSessionId(), command);
+            return message;
+        }
+
+        String jti = jwtProvider.getJti(accessToken);
+        String isLogout = redisTemplate.opsForValue().get(AuthConstant.BLACKLIST_PREFIX + jti);
+
+        if (!ObjectUtils.isEmpty(isLogout)) {
+            log.warn("Ignoring STOMP frame with blacklisted token. sessionId={}, command={}", accessor.getSessionId(), command);
+            return message;
+        }
+
+        Authentication authentication = jwtProvider.getAuthentication(accessToken);
+        accessor.setUser(authentication);
+
+        return message;
+    }
+
+    private boolean requiresAuthentication(StompCommand command) {
+        return StompCommand.CONNECT.equals(command)
+                || StompCommand.SEND.equals(command)
+                || StompCommand.SUBSCRIBE.equals(command);
+    }
+
+    private String resolveToken(StompHeaderAccessor accessor) {
+        String authorization = firstNativeHeader(
+                accessor,
+                AUTHORIZATION_HEADER,
+                AUTHORIZATION_HEADER_LOWER_CASE
+        );
+
+        if (StringUtils.hasText(authorization)) {
+            String value = authorization.trim();
+            if (value.startsWith(BEARER_PREFIX)) {
+                return value.substring(BEARER_PREFIX.length());
+            }
+            return value;
+        }
+
+        String token = firstNativeHeader(accessor, TOKEN_HEADER, ACCESS_TOKEN_HEADER);
+        if (StringUtils.hasText(token)) {
+            return token.trim();
+        }
+
+        return null;
+    }
+
+    private String firstNativeHeader(StompHeaderAccessor accessor, String... headerNames) {
+        for (String headerName : headerNames) {
+            String value = accessor.getFirstNativeHeader(headerName);
+            if (StringUtils.hasText(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/kr/inventory/global/auth/util/PrincipalUtils.java
+++ b/src/main/java/kr/inventory/global/auth/util/PrincipalUtils.java
@@ -1,0 +1,37 @@
+package kr.inventory.global.auth.util;
+
+import java.security.Principal;
+import kr.inventory.domain.auth.exception.AuthErrorCode;
+import kr.inventory.domain.auth.exception.AuthException;
+import kr.inventory.domain.auth.security.CustomUserDetails;
+import org.springframework.security.core.Authentication;
+
+public final class PrincipalUtils {
+
+    private PrincipalUtils() {
+        throw new UnsupportedOperationException("Utility class cannot be instantiated");
+    }
+
+    public static Long extractUserId(Principal principal) {
+        if (principal instanceof Authentication authentication) {
+            Object authenticationPrincipal = authentication.getPrincipal();
+            if (authenticationPrincipal instanceof CustomUserDetails userDetails) {
+                return userDetails.getUserId();
+            }
+        }
+
+        if (principal instanceof CustomUserDetails userDetails) {
+            return userDetails.getUserId();
+        }
+
+        if (principal == null || principal.getName() == null) {
+            throw new AuthException(AuthErrorCode.USER_INFO_NOT_FOUND);
+        }
+
+        try {
+            return Long.parseLong(principal.getName());
+        } catch (NumberFormatException e) {
+            throw new AuthException(AuthErrorCode.INVALID_USER_ID_FORMAT);
+        }
+    }
+}

--- a/src/main/java/kr/inventory/global/config/SecurityConfig.java
+++ b/src/main/java/kr/inventory/global/config/SecurityConfig.java
@@ -64,7 +64,10 @@ public class SecurityConfig {
                                 "/actuator/**"
                         ).permitAll()
 
-                        // Public customer-facing APIs
+                        // WebSocket (STOMP)
+                        .requestMatchers("/ws/**").permitAll()
+
+                        // Public customer
                         .requestMatchers(HttpMethod.GET, "/api/menus/*/customer").permitAll()
                         .requestMatchers("/api/table-sessions/**").permitAll()
                         .requestMatchers("/api/dining/**").permitAll()
@@ -72,7 +75,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/chat/**").permitAll()
                         .requestMatchers("/api/mcp-test/**").permitAll()
 
-                        // Backoffice APIs
+                        // Backoffice
                         .requestMatchers("/api/users/**").authenticated()
                         .requestMatchers("/api/stores/**").authenticated()
                         .requestMatchers("/api/menus/**").authenticated()

--- a/src/main/java/kr/inventory/global/config/WebSocketConfig.java
+++ b/src/main/java/kr/inventory/global/config/WebSocketConfig.java
@@ -1,6 +1,9 @@
 package kr.inventory.global.config;
 
+import kr.inventory.global.auth.interceptor.StompAuthChannelInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,11 +11,20 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws");
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompAuthChannelInterceptor);
     }
 
     @Override


### PR DESCRIPTION
## 이슈 번호
- Closes #177

## 작업 내용
- WebSocket STOMP 연결 시 JWT 인증을 처리할 수 있도록 인터셉터를 추가
- 다양한 헤더 및 쿼리 파라미터에서 토큰을 추출할 수 있도록 개선
