### PR TITLE
fix: 웹소켓 개발/운영 서버 분리, 챗봇 상세 추적용 로그 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
     build:
       context: ../AIBE4_FinalProject_Team1_FE
       dockerfile: Dockerfile
+      args:
+        BUILD_MODE: dev
     container_name: inventory-web
     depends_on:
       backend:

--- a/src/main/java/kr/inventory/domain/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/kr/inventory/domain/chat/controller/ChatWebSocketController.java
@@ -2,7 +2,6 @@ package kr.inventory.domain.chat.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
-import java.security.Principal;
 import kr.inventory.domain.chat.controller.dto.request.ChatSendMessageRequest;
 import kr.inventory.domain.chat.service.ChatCommandService;
 import kr.inventory.global.util.WebSocketUtil;
@@ -10,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
 
 @Controller
 @RequiredArgsConstructor
@@ -23,8 +24,9 @@ public class ChatWebSocketController {
             @Payload @Valid ChatSendMessageRequest request,
             Principal principal
     ) {
+        Long userId = WebSocketUtil.extractUserId(principal);
         chatCommandService.acceptUserMessage(
-                WebSocketUtil.extractUserId(principal),
+                userId,
                 request.threadId(),
                 request.clientMessageId(),
                 request.content()

--- a/src/main/java/kr/inventory/domain/chat/service/ChatCommandService.java
+++ b/src/main/java/kr/inventory/domain/chat/service/ChatCommandService.java
@@ -7,9 +7,11 @@ import kr.inventory.domain.chat.exception.ChatErrorCode;
 import kr.inventory.domain.chat.exception.ChatException;
 import kr.inventory.domain.chat.service.command.AcceptedUserMessageResult;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatCommandService {
@@ -29,8 +31,13 @@ public class ChatCommandService {
             String rawClientMessageId,
             String rawContent
     ) {
+        log.info("[ChatCommand] Accepting user message - userId: {}, threadId: {}, clientMessageId: {}, contentLength: {}",
+                userId, threadId, rawClientMessageId, rawContent != null ? rawContent.length() : 0);
+
         String clientMessageId = normalizeClientMessageId(rawClientMessageId);
         String content = normalizeContent(rawContent);
+
+        log.debug("[ChatCommand] After normalization - clientMessageId: {}, content: {}", clientMessageId, content);
 
         AcceptedUserMessageResult accepted = chatPersistenceService.persistUserMessage(
                 userId,
@@ -39,8 +46,13 @@ public class ChatCommandService {
                 content
         );
 
+        log.info("[ChatCommand] Message persisted - messageId: {}", accepted.requestMessage().messageId());
+
         chatPushService.sendAccepted(accepted);
+        log.debug("[ChatCommand] Accepted event sent to user");
+
         chatThreadDispatchService.dispatchHeadOfLine(accepted.requestMessage().threadId());
+        log.debug("[ChatCommand] Message dispatched to worker");
     }
 
     private String normalizeTitle(String rawTitle) {

--- a/src/main/java/kr/inventory/global/auth/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/kr/inventory/global/auth/interceptor/StompAuthChannelInterceptor.java
@@ -33,12 +33,19 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             return message;
         }
 
+        log.debug("[StompInterceptor] Received STOMP message - command: {}, destination: {}, sessionId: {}",
+                accessor.getCommand(), accessor.getDestination(), accessor.getSessionId());
+
         if (!requiresAuthentication(accessor.getCommand()) || accessor.getUser() != null) {
+            log.debug("[StompInterceptor] Skipping auth - command: {}, requiresAuth: {}, hasUser: {}",
+                    accessor.getCommand(), requiresAuthentication(accessor.getCommand()), accessor.getUser() != null);
             return message;
         }
 
         String accessToken = resolveToken(accessor);
         if (!StringUtils.hasText(accessToken)) {
+            log.warn("[StompInterceptor] No access token found - command: {}, sessionId: {}",
+                    accessor.getCommand(), accessor.getSessionId());
             return message;
         }
 


### PR DESCRIPTION
## 이슈 번호
- Closes #188

## 작업 내용
- 웹소켓 개발/운영 서버 분리
- 챗봇 상세 추적용 로그 추가