### PR TITLE
refactor: 입고 목록 필터링, 챗봇 리팩토링(통합테스트 대응)

### DIFF
--- a/src/main/java/kr/inventory/ai/sales/constant/SalesConstants.java
+++ b/src/main/java/kr/inventory/ai/sales/constant/SalesConstants.java
@@ -6,6 +6,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public final class SalesConstants {
 
@@ -20,6 +21,8 @@ public final class SalesConstants {
     public static final int DEFAULT_PAGE = 1;
     public static final int DEFAULT_SIZE = 10;
     public static final int MAX_SIZE = 50;
+
+    public static final Set<String> SUPPORTED_VIEW_TYPES = Set.of("combined", "day_only", "hour_only");
 
     public static final Map<String, String> STATUS_ALIASES = Map.ofEntries(
             Map.entry("완료", "COMPLETED"),

--- a/src/main/java/kr/inventory/ai/sales/tool/dto/request/SalesOrderDetailToolRequest.java
+++ b/src/main/java/kr/inventory/ai/sales/tool/dto/request/SalesOrderDetailToolRequest.java
@@ -1,6 +1,7 @@
 package kr.inventory.ai.sales.tool.dto.request;
 
 import kr.inventory.ai.common.enums.DateRangePreset;
+import kr.inventory.ai.sales.constant.SalesConstants;
 import kr.inventory.ai.sales.tool.support.SalesToolDateRange;
 import kr.inventory.ai.sales.tool.support.SalesToolDateRangeResolver;
 import kr.inventory.domain.sales.entity.enums.SalesOrderStatus;
@@ -10,7 +11,6 @@ import kr.inventory.domain.sales.service.command.SalesLedgerSortBy;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Locale;
-import java.util.Map;
 import java.util.UUID;
 
 public record SalesOrderDetailToolRequest(
@@ -27,26 +27,6 @@ public record SalesOrderDetailToolRequest(
         String sortBy,
         Integer selectionIndex
 ) {
-    private static final Map<String, String> STATUS_ALIASES = Map.ofEntries(
-            Map.entry("완료", "COMPLETED"),
-            Map.entry("주문완료", "COMPLETED"),
-            Map.entry("completed", "COMPLETED"),
-            Map.entry("환불", "REFUNDED"),
-            Map.entry("환불주문", "REFUNDED"),
-            Map.entry("refunded", "REFUNDED"),
-            Map.entry("refund", "REFUNDED")
-    );
-
-    private static final Map<String, String> TYPE_ALIASES = Map.ofEntries(
-            Map.entry("홀", "DINE_IN"),
-            Map.entry("매장", "DINE_IN"),
-            Map.entry("매장식사", "DINE_IN"),
-            Map.entry("dinein", "DINE_IN"),
-            Map.entry("dine_in", "DINE_IN"),
-            Map.entry("포장", "TAKEOUT"),
-            Map.entry("takeout", "TAKEOUT"),
-            Map.entry("take_out", "TAKEOUT")
-    );
     public SalesToolDateRange resolvedDateRange() {
         return SalesToolDateRangeResolver.resolve(period, fromDate, toDate, DateRangePreset.LAST_7_DAYS);
     }
@@ -170,11 +150,11 @@ public record SalesOrderDetailToolRequest(
         String trimmed = value.trim();
         String aliasKey = trimmed.replace(" ", "").replace("-", "").toLowerCase(Locale.ROOT);
 
-        if (STATUS_ALIASES.containsKey(aliasKey)) {
-            return STATUS_ALIASES.get(aliasKey);
+        if (SalesConstants.STATUS_ALIASES.containsKey(aliasKey)) {
+            return SalesConstants.STATUS_ALIASES.get(aliasKey);
         }
-        if (TYPE_ALIASES.containsKey(aliasKey)) {
-            return TYPE_ALIASES.get(aliasKey);
+        if (SalesConstants.TYPE_ALIASES.containsKey(aliasKey)) {
+            return SalesConstants.TYPE_ALIASES.get(aliasKey);
         }
 
         return trimmed

--- a/src/main/java/kr/inventory/ai/sales/tool/dto/request/SalesPeakToolRequest.java
+++ b/src/main/java/kr/inventory/ai/sales/tool/dto/request/SalesPeakToolRequest.java
@@ -1,12 +1,12 @@
 package kr.inventory.ai.sales.tool.dto.request;
 
 import kr.inventory.ai.common.enums.DateRangePreset;
+import kr.inventory.ai.sales.constant.SalesConstants;
 import kr.inventory.ai.sales.tool.support.SalesToolDateRange;
 import kr.inventory.ai.sales.tool.support.SalesToolDateRangeResolver;
 
 import java.time.LocalDate;
 import java.util.Locale;
-import java.util.Set;
 
 public record SalesPeakToolRequest(
         DateRangePreset period,
@@ -15,8 +15,6 @@ public record SalesPeakToolRequest(
         Integer limit,
         String viewType
 ) {
-    private static final Set<String> SUPPORTED_VIEW_TYPES = Set.of("combined", "day_only", "hour_only");
-
     public boolean hasExplicitDateRange() {
         return fromDate != null && toDate != null;
     }
@@ -34,7 +32,7 @@ public record SalesPeakToolRequest(
 
     public String resolvedViewType() {
         String normalized = normalizedViewType();
-        if (!SUPPORTED_VIEW_TYPES.contains(normalized)) {
+        if (!SalesConstants.SUPPORTED_VIEW_TYPES.contains(normalized)) {
             throw new IllegalArgumentException("viewType must be combined, day_only, or hour_only");
         }
         return normalized;

--- a/src/main/java/kr/inventory/domain/chat/service/ChatPromptService.java
+++ b/src/main/java/kr/inventory/domain/chat/service/ChatPromptService.java
@@ -45,6 +45,10 @@ public class ChatPromptService {
             Use this metadata to provide contextually relevant follow-up questions.
             Do not repeat the same actionKey + periodKey combination that was just executed.
             When suggesting follow-up questions, prefer different analysis types or time periods.
+            IMPORTANT: Maintain domain consistency in follow-up suggestions.
+            If the current response is about stock or inbound records, only suggest stock-related follow-ups.
+            If the current response is about sales, orders, or menu performance, only suggest sales-related follow-ups.
+            Do not mix stock and sales domains in the same follow-up suggestion set.
             End your response with a section titled exactly "### 추천 질문" when useful follow-ups exist.
             In that section, provide 2 to 3 bullet items based on the suggestedFollowUps metadata.
             Each bullet should be a natural Korean question that aligns with the suggested action.

--- a/src/main/java/kr/inventory/domain/stock/controller/StockInboundController.java
+++ b/src/main/java/kr/inventory/domain/stock/controller/StockInboundController.java
@@ -129,7 +129,7 @@ public class StockInboundController {
             @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable UUID storePublicId,
             @ModelAttribute StockInboundSearchRequest searchRequest,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 20) Pageable pageable
     ) {
         PageResponse<StockInboundListResponse> response = stockInboundService.getInbounds(
                 principal.getUserId(),


### PR DESCRIPTION
## 이슈 번호
- Closes #242

## 작업 내용
- 입고 목록 필터링 수정 및 정렬 제거
- 챗봇 프롬프트 추가(llm이 제공해주는 선택지 재고->재고 / 매출->매출 끼리만 매핑 되도록)
