### PR TITLE
feat: WebSocket 성능 최적화

### DIFF
--- a/src/main/java/kr/inventory/domain/chat/controller/support/ChatWebSocketExceptionHandler.java
+++ b/src/main/java/kr/inventory/domain/chat/controller/support/ChatWebSocketExceptionHandler.java
@@ -1,0 +1,101 @@
+package kr.inventory.domain.chat.controller.support;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.OffsetDateTime;
+import kr.inventory.domain.chat.constant.ChatConstants;
+import kr.inventory.domain.chat.controller.dto.request.ChatSendMessageRequest;
+import kr.inventory.domain.chat.controller.dto.response.ChatRealtimeEventResponse;
+import kr.inventory.domain.chat.controller.dto.response.ChatRealtimeEventType;
+import kr.inventory.domain.chat.entity.enums.ChatMessageStatus;
+import kr.inventory.domain.chat.exception.ChatException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+@Slf4j
+@ControllerAdvice
+@RequiredArgsConstructor
+public class ChatWebSocketExceptionHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @MessageExceptionHandler(Exception.class)
+    @SendToUser(destinations = ChatConstants.USER_QUEUE_DESTINATION, broadcast = false)
+    public ChatRealtimeEventResponse handleException(Exception exception, Message<?> message) {
+        ChatSendMessageRequest request = extractRequest(message);
+        String sessionId = SimpMessageHeaderAccessor.getSessionId(message.getHeaders());
+        String destination = SimpMessageHeaderAccessor.getDestination(message.getHeaders());
+
+        log.warn(
+                "Handled chat WebSocket exception. sessionId={}, destination={}, threadId={}, clientMessageId={}, reason={}",
+                sessionId,
+                destination,
+                request != null ? request.threadId() : null,
+                request != null ? request.clientMessageId() : null,
+                exception.getMessage(),
+                exception
+        );
+
+        return new ChatRealtimeEventResponse(
+                ChatRealtimeEventType.CHAT_FAILED,
+                request != null ? request.threadId() : null,
+                null,
+                request != null ? request.clientMessageId() : null,
+                ChatMessageStatus.FAILED,
+                null,
+                resolveErrorMessage(exception),
+                OffsetDateTime.now()
+        );
+    }
+
+    private ChatSendMessageRequest extractRequest(Message<?> message) {
+        if (message == null) {
+            return null;
+        }
+
+        Object payload = message.getPayload();
+        if (payload instanceof ChatSendMessageRequest request) {
+            return request;
+        }
+
+        try {
+            if (payload instanceof byte[] bytes) {
+                return objectMapper.readValue(bytes, ChatSendMessageRequest.class);
+            }
+
+            if (payload instanceof String text) {
+                return objectMapper.readValue(text, ChatSendMessageRequest.class);
+            }
+        } catch (Exception ignored) {
+            return null;
+        }
+
+        return null;
+    }
+
+    private String resolveErrorMessage(Exception exception) {
+        if (exception instanceof ChatException chatException) {
+            return chatException.getMessage();
+        }
+
+        if (exception instanceof MethodArgumentNotValidException validationException) {
+            FieldError fieldError = validationException.getBindingResult().getFieldError();
+            if (fieldError != null && fieldError.getDefaultMessage() != null) {
+                return fieldError.getDefaultMessage();
+            }
+        }
+
+        String message = exception.getMessage();
+        if (message == null || message.isBlank()) {
+            return "채팅 요청을 처리하지 못했습니다.";
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/kr/inventory/global/auth/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/kr/inventory/global/auth/interceptor/StompAuthChannelInterceptor.java
@@ -36,17 +36,25 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         log.debug("[StompInterceptor] Received STOMP message - command: {}, destination: {}, sessionId: {}",
                 accessor.getCommand(), accessor.getDestination(), accessor.getSessionId());
 
-        if (!requiresAuthentication(accessor.getCommand()) || accessor.getUser() != null) {
-            log.debug("[StompInterceptor] Skipping auth - command: {}, requiresAuth: {}, hasUser: {}",
-                    accessor.getCommand(), requiresAuthentication(accessor.getCommand()), accessor.getUser() != null);
+        if (!requiresAuthentication(accessor.getCommand())) {
+            return message;
+        }
+
+        if (accessor.getUser() != null) {
+            return message;
+        }
+
+        Authentication sessionAuthentication = resolveSessionAuthentication(accessor);
+        if (sessionAuthentication != null) {
+            accessor.setUser(sessionAuthentication);
             return message;
         }
 
         String accessToken = resolveToken(accessor);
         if (!StringUtils.hasText(accessToken)) {
-            log.warn("[StompInterceptor] No access token found - command: {}, sessionId: {}",
+            log.warn("[StompInterceptor] Rejecting STOMP frame without access token - command: {}, sessionId: {}",
                     accessor.getCommand(), accessor.getSessionId());
-            return message;
+            return null;
         }
 
         if (!jwtProvider.validateToken(accessToken)) {
@@ -74,6 +82,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
         Authentication authentication = jwtProvider.getAuthentication(accessToken);
         accessor.setUser(authentication);
+        storeSessionAuthentication(accessor, authentication);
         return message;
     }
 
@@ -81,6 +90,29 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         return StompCommand.CONNECT.equals(command)
                 || StompCommand.SEND.equals(command)
                 || StompCommand.SUBSCRIBE.equals(command);
+    }
+
+    private Authentication resolveSessionAuthentication(StompHeaderAccessor accessor) {
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        if (sessionAttributes == null || sessionAttributes.isEmpty()) {
+            return null;
+        }
+
+        Object value = sessionAttributes.get(WebSocketConstants.SESSION_AUTHENTICATION);
+        if (value instanceof Authentication authentication) {
+            return authentication;
+        }
+
+        return null;
+    }
+
+    private void storeSessionAuthentication(StompHeaderAccessor accessor, Authentication authentication) {
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        if (sessionAttributes == null) {
+            return;
+        }
+
+        sessionAttributes.put(WebSocketConstants.SESSION_AUTHENTICATION, authentication);
     }
 
     private String resolveToken(StompHeaderAccessor accessor) {

--- a/src/main/java/kr/inventory/global/config/WebSocketConfig.java
+++ b/src/main/java/kr/inventory/global/config/WebSocketConfig.java
@@ -2,13 +2,17 @@ package kr.inventory.global.config;
 
 import kr.inventory.global.auth.interceptor.JwtHandshakeInterceptor;
 import kr.inventory.global.auth.interceptor.StompAuthChannelInterceptor;
+import kr.inventory.global.constant.WebSocketConstants;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -17,28 +21,63 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
     private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
+    private final CorsProperties corsProperties;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws")
-                .addInterceptors(jwtHandshakeInterceptor)
-                .setAllowedOriginPatterns("*");
+        String[] allowedOriginPatterns = corsProperties.getAllowedOrigins().toArray(String[]::new);
 
         registry.addEndpoint("/ws")
                 .addInterceptors(jwtHandshakeInterceptor)
-                .setAllowedOriginPatterns("*")
+                .setAllowedOriginPatterns(allowedOriginPatterns);
+
+        registry.addEndpoint("/ws")
+                .addInterceptors(jwtHandshakeInterceptor)
+                .setAllowedOriginPatterns(allowedOriginPatterns)
                 .withSockJS();
     }
 
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompAuthChannelInterceptor);
+        registration.taskExecutor()
+                .corePoolSize(WebSocketConstants.INBOUND_CORE_POOL_SIZE)
+                .maxPoolSize(WebSocketConstants.INBOUND_MAX_POOL_SIZE)
+                .queueCapacity(WebSocketConstants.CHANNEL_QUEUE_CAPACITY);
+    }
+
+    @Override
+    public void configureClientOutboundChannel(ChannelRegistration registration) {
+        registration.taskExecutor()
+                .corePoolSize(WebSocketConstants.OUTBOUND_CORE_POOL_SIZE)
+                .maxPoolSize(WebSocketConstants.OUTBOUND_MAX_POOL_SIZE)
+                .queueCapacity(WebSocketConstants.CHANNEL_QUEUE_CAPACITY);
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/topic", "/queue");
+        registry.enableSimpleBroker("/topic", "/queue")
+                .setHeartbeatValue(WebSocketConstants.SIMPLE_BROKER_HEARTBEAT)
+                .setTaskScheduler(webSocketBrokerTaskScheduler());
         registry.setApplicationDestinationPrefixes("/app");
         registry.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void configureWebSocketTransport(WebSocketTransportRegistration registry) {
+        registry.setMessageSizeLimit(WebSocketConstants.MESSAGE_SIZE_LIMIT)
+                .setSendBufferSizeLimit(WebSocketConstants.SEND_BUFFER_SIZE_LIMIT)
+                .setSendTimeLimit(WebSocketConstants.SEND_TIME_LIMIT_MS)
+                .setTimeToFirstMessage(WebSocketConstants.TIME_TO_FIRST_MESSAGE_MS);
+    }
+
+    @Bean
+    public ThreadPoolTaskScheduler webSocketBrokerTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(2);
+        scheduler.setThreadNamePrefix("ws-broker-heartbeat-");
+        scheduler.setRemoveOnCancelPolicy(true);
+        scheduler.initialize();
+        return scheduler;
     }
 }

--- a/src/main/java/kr/inventory/global/constant/WebSocketConstants.java
+++ b/src/main/java/kr/inventory/global/constant/WebSocketConstants.java
@@ -2,6 +2,9 @@ package kr.inventory.global.constant;
 
 public final class WebSocketConstants {
 
+    private WebSocketConstants() {
+    }
+
     // Authorization 헤더
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String AUTHORIZATION_HEADER_LOWER_CASE = "authorization";
@@ -12,6 +15,7 @@ public final class WebSocketConstants {
     // WebSocket 세션 속성
     public static final String SESSION_AUTHORIZATION = "WS_AUTHORIZATION";
     public static final String SESSION_ACCESS_TOKEN = "WS_ACCESS_TOKEN";
+    public static final String SESSION_AUTHENTICATION = "WS_AUTHENTICATION";
 
     // Query 파라미터
     public static final String TOKEN_PARAM = "token";
@@ -35,4 +39,17 @@ public final class WebSocketConstants {
     // 에러 메시지
     public static final String ERROR_NO_USER_INFO = "인증된 사용자 정보를 찾을 수 없습니다.";
     public static final String ERROR_INVALID_USER_ID = "사용자 식별자를 해석할 수 없습니다.";
+
+    // WebSocket 설정 상수
+    public static final long[] SIMPLE_BROKER_HEARTBEAT = {10000L, 10000L};
+    public static final int INBOUND_CORE_POOL_SIZE = 4;
+    public static final int INBOUND_MAX_POOL_SIZE = 16;
+    public static final int OUTBOUND_CORE_POOL_SIZE = 4;
+    public static final int OUTBOUND_MAX_POOL_SIZE = 16;
+    public static final int CHANNEL_QUEUE_CAPACITY = 1000;
+    public static final int MESSAGE_SIZE_LIMIT = 64 * 1024;
+    public static final int SEND_BUFFER_SIZE_LIMIT = 512 * 1024;
+    public static final int SEND_TIME_LIMIT_MS = 15_000;
+    public static final int TIME_TO_FIRST_MESSAGE_MS = 60_000;
+
 }

--- a/src/main/java/kr/inventory/global/websocket/WebSocketSessionEventListener.java
+++ b/src/main/java/kr/inventory/global/websocket/WebSocketSessionEventListener.java
@@ -1,0 +1,50 @@
+package kr.inventory.global.websocket;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+@Slf4j
+@Component
+public class WebSocketSessionEventListener {
+
+    @EventListener
+    public void onSessionConnect(SessionConnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        log.info("[WebSocket] CONNECT sessionId={}, user={}, destination={}",
+                accessor.getSessionId(),
+                accessor.getUser() != null ? accessor.getUser().getName() : null,
+                accessor.getDestination());
+    }
+
+    @EventListener
+    public void onSessionConnected(SessionConnectedEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        log.info("[WebSocket] CONNECTED sessionId={}, user={}",
+                accessor.getSessionId(),
+                accessor.getUser() != null ? accessor.getUser().getName() : null);
+    }
+
+    @EventListener
+    public void onSessionSubscribe(SessionSubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        log.info("[WebSocket] SUBSCRIBE sessionId={}, user={}, destination={}",
+                accessor.getSessionId(),
+                accessor.getUser() != null ? accessor.getUser().getName() : null,
+                accessor.getDestination());
+    }
+
+    @EventListener
+    public void onSessionDisconnect(SessionDisconnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        log.info("[WebSocket] DISCONNECT sessionId={}, user={}, closeStatus={}",
+                accessor.getSessionId(),
+                accessor.getUser() != null ? accessor.getUser().getName() : null,
+                event.getCloseStatus());
+    }
+}


### PR DESCRIPTION
## 이슈 번호
- Closes #256

## 작업 내용
  성능 최적화                                                                                                                                                                                                             
  - Inbound/Outbound 채널에 전용 스레드 풀 구성: 코어 풀 크기 4, 최대 풀 크기 16, 큐 용량 1000으로 설정하여   
  동시 메시지 처리 능력 향상                                                                                  
  - 메시지 크기 및 버퍼 제한 설정: 메시지 크기 64KB, 전송 버퍼 512KB로 제한하여 메모리 사용 최적화            
  - 전송 타임아웃 설정: 메시지 전송 제한 시간 15초, 첫 메시지 대기 60초로 설정하여 비정상 연결 조기 차단      
  - Simple Broker 하트비트 구성: 10초 간격 하트비트로 연결 상태 모니터링 및 불필요한 연결 정리                
  - 하트비트 전용 ThreadPoolTaskScheduler 추가: 풀 크기 2로 하트비트 처리 성능 개선                           
                                                                                                              
  보안 강화                                                                                                                                                                                                                 
  - CORS 설정 개선: 와일드카드(*)에서 구체적인 allowedOrigins로 변경하여 보안 강화                            
  - 인증 실패 시 메시지 거부: 토큰 없는 STOMP 프레임을 null 반환으로 차단 (기존에는 통과시킴)                 
  - 세션 기반 인증 캐싱: Authentication 객체를 WebSocket 세션에 저장하여 매 메시지마다 JWT 검증하는 오버헤드  
  제거                                                                                                        
                                                                                                              
  코드 구조 개선                                                                                                                                                                                                           
  - WebSocket 설정 상수 중앙화: WebSocketConfig의 모든 상수를 WebSocketConstants로 이동하여 중앙 관리         
  - 상수 클래스 패턴 적용: WebSocketConstants에 private 생성자 추가하여 인스턴스화 방지                       
  - 인증 로직 단순화: StompAuthChannelInterceptor의 조건문 분리로 가독성 향상                                 
                                                                                                              
  예외 처리 및 모니터링                                                                                                              
  - WebSocket 예외 핸들러 추가: ChatWebSocketExceptionHandler로 모든 WebSocket 예외를 일관되게 처리하고       
  사용자에게 적절한 에러 응답 반환                                                                            
  - 세션 이벤트 리스너 추가: WebSocketSessionEventListener로 CONNECT/CONNECTED/SUBSCRIBE/DISCONNECT 이벤트    
  로깅하여 디버깅 및 모니터링 강화                                                                            
  - 세션 정보 로깅 개선: sessionId, user, destination 정보를 포함한 상세 로그 기록