### PR TITLE
feat: Jaccard 기반 재료 추천 로직을 top1 + 최소 점수 기준으로 변경

### DIFF
--- a/src/main/java/kr/inventory/domain/stock/normalization/constant/InboundItemResolutionConstants.java
+++ b/src/main/java/kr/inventory/domain/stock/normalization/constant/InboundItemResolutionConstants.java
@@ -5,9 +5,8 @@ import java.util.regex.Pattern;
 
 public final class InboundItemResolutionConstants {
 
-    public static final double AUTO_SCORE_THRESHOLD = 0.85;
-    public static final double AUTO_GAP_THRESHOLD = 0.25;
-    public static final int TOP_N_CANDIDATES = 5;
+    // 2차 Jaccard 스코어링에서는 top1만 사용하고, 점수가 이 값보다 낮으면 추천하지 않는다.
+    public static final double TOP1_MIN_SCORE_THRESHOLD = 0.25;
 
     public static final Set<String> STOP_WORDS = Set.of(
             // 법인/회사 표기
@@ -64,4 +63,7 @@ public final class InboundItemResolutionConstants {
 
     public static final Pattern PROMOTION_PACK_TOKEN =
             Pattern.compile("^\\d+[x*+]\\d+$|^\\d+개입$", Pattern.CASE_INSENSITIVE);
+
+    private InboundItemResolutionConstants() {
+    }
 }

--- a/src/main/java/kr/inventory/domain/stock/normalization/service/IngredientResolutionService.java
+++ b/src/main/java/kr/inventory/domain/stock/normalization/service/IngredientResolutionService.java
@@ -159,18 +159,10 @@ public class IngredientResolutionService {
         if (activeIngredients != null && !activeIngredients.isEmpty()) {
             List<ScoredCandidate> scored = scoreCandidates(tokens, activeIngredients, inboundItem);
             if (!scored.isEmpty()) {
-                List<ScoredCandidate> top = scored.stream()
-                        .limit(InboundItemResolutionConstants.TOP_N_CANDIDATES)
-                        .toList();
+                ScoredCandidate topCandidate = scored.get(0);
 
-                double topScore = top.get(0).score;
-                double secondScore = top.size() >= 2 ? top.get(1).score : 0.0;
-
-                boolean confidentAuto = topScore >= InboundItemResolutionConstants.AUTO_SCORE_THRESHOLD
-                        && (top.size() == 1 || (topScore - secondScore >= InboundItemResolutionConstants.AUTO_GAP_THRESHOLD));
-
-                if (confidentAuto) {
-                    Ingredient chosen = top.get(0).ingredient;
+                if (topCandidate.score >= InboundItemResolutionConstants.TOP1_MIN_SCORE_THRESHOLD) {
+                    Ingredient chosen = topCandidate.ingredient;
                     inboundItem.updateResolution(ResolutionStatus.AUTO_SUGGESTED, chosen, null);
                     applyNormalizedQuantity(inboundItem, chosen);
                     updateInboundItemKeyToIngredientNormalizedName(inboundItem, chosen, normalizedFull);
@@ -381,7 +373,6 @@ public class IngredientResolutionService {
         inboundItem.updateNormalizedQuantity(result.normalizedQuantity());
     }
 
-
     private boolean isUnitCompatible(StockInboundItem inboundItem, Ingredient ingredient) {
         if (ingredient == null || ingredient.getUnit() == null) {
             return true;
@@ -440,8 +431,8 @@ public class IngredientResolutionService {
     }
 
     private List<ScoredCandidate> scoreCandidates(List<String> tokens,
-                                               List<Ingredient> ingredients,
-                                               StockInboundItem inboundItem) {
+                                                  List<Ingredient> ingredients,
+                                                  StockInboundItem inboundItem) {
         Set<String> query = tokens.stream()
                 .map(t -> t.trim().toLowerCase())
                 .filter(t -> !t.isBlank())


### PR DESCRIPTION
## 이슈 번호

## 작업 내용
- Jaccard 기반 재료 추천 로직을 top1 + 최소 점수 기준으로 변경