### PR TITLE
feat : Prometheus/Grafana 기반 챗봇 관측 대시보드 구성

### DIFF
--- a/monitoring/grafana/dashboards/chatbot-performance-dashboard.json
+++ b/monitoring/grafana/dashboards/chatbot-performance-dashboard.json
@@ -1,0 +1,303 @@
+{
+  "uid": "chatbot-performance",
+  "title": "Chatbot Performance Dashboard",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 2,
+  "refresh": "5s",
+  "tags": [
+    "chatbot",
+    "redis-streams",
+    "worker"
+  ],
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Queue Wait p95",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(increase(chat_queue_wait_seconds_bucket[$__range])) by (le)) or vector(0)",
+          "legendFormat": "p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "title": "Worker Processing p95",
+      "type": "stat",
+      "gridPos": {
+        "x": 6,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(increase(chat_worker_processing_seconds_bucket[$__range])) by (le)) or vector(0)",
+          "legendFormat": "p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "title": "Active / Busy Workers",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "chat_worker_active",
+          "legendFormat": "active"
+        },
+        {
+          "expr": "chat_worker_busy",
+          "legendFormat": "busy"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "title": "Stream Backlog",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 18,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "chat_stream_backlog",
+          "legendFormat": "backlog"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "title": "Queue Wait p50 / p95",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 12,
+        "h": 7
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(increase(chat_queue_wait_seconds_bucket[$__range])) by (le)) or vector(0)",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(increase(chat_queue_wait_seconds_bucket[$__range])) by (le)) or vector(0)",
+          "legendFormat": "p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "title": "Worker Processing p50 / p95 by Outcome",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 4,
+        "w": 12,
+        "h": 7
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(increase(chat_worker_processing_seconds_bucket[$__range])) by (le, outcome)) or vector(0)",
+          "legendFormat": "{{outcome}} p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(increase(chat_worker_processing_seconds_bucket[$__range])) by (le, outcome)) or vector(0)",
+          "legendFormat": "{{outcome}} p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "title": "LLM Phase Duration p95 by Outcome",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 11,
+        "w": 12,
+        "h": 7
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(increase(chat_llm_duration_seconds_bucket[$__range])) by (le, phase, outcome)) or vector(0)",
+          "legendFormat": "{{phase}} {{outcome}} p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 8,
+      "title": "Accepted / Published / Skipped (range count)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 11,
+        "w": 12,
+        "h": 7
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(chat_message_accepted_total[$__range])) or vector(0)",
+          "legendFormat": "accepted"
+        },
+        {
+          "expr": "sum(increase(chat_stream_published_total[$__range])) or vector(0)",
+          "legendFormat": "stream published"
+        },
+        {
+          "expr": "sum(increase(chat_worker_skipped_total[$__range])) or vector(0)",
+          "legendFormat": "worker skipped"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 9,
+      "title": "Worker Scale Events (range count)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 18,
+        "w": 12,
+        "h": 6
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(chat_worker_scale_events_total[$__range])) by (direction)",
+          "legendFormat": "{{direction}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 10,
+      "title": "Interrupt Requests (range count)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 18,
+        "w": 12,
+        "h": 6
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(chat_interrupt_requested_total[$__range])) or vector(0)",
+          "legendFormat": "interrupts"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 11,
+      "title": "LLM Calls by Outcome / Error Type",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 24,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(chat_llm_calls_total[$__range])) by (phase, outcome, error_type)",
+          "legendFormat": "{{phase}} {{outcome}} {{error_type}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/chatbot-dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/chatbot-dashboard.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: Chatbot Dashboards
+    orgId: 1
+    folder: Chatbot
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: true

--- a/src/main/java/kr/inventory/domain/chat/monitoring/ChatMetricsRecorder.java
+++ b/src/main/java/kr/inventory/domain/chat/monitoring/ChatMetricsRecorder.java
@@ -1,0 +1,194 @@
+package kr.inventory.domain.chat.monitoring;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import kr.inventory.global.llm.exception.LlmQuotaExceededException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class ChatMetricsRecorder {
+
+    private static final String OUTCOME = "outcome";
+    private static final String PHASE = "phase";
+    private static final String REASON = "reason";
+    private static final String DIRECTION = "direction";
+    private static final String DUPLICATED = "duplicated";
+    private static final String MODEL = "model";
+    private static final String ERROR_TYPE = "error_type";
+
+    private final MeterRegistry meterRegistry;
+
+    private final AtomicInteger activeWorkers = new AtomicInteger();
+    private final AtomicInteger busyWorkers = new AtomicInteger();
+    private final AtomicLong streamBacklog = new AtomicLong();
+
+    @jakarta.annotation.PostConstruct
+    public void registerGauges() {
+        Gauge.builder("chat.worker.active", activeWorkers, AtomicInteger::get)
+                .description("Active chat stream worker count")
+                .register(meterRegistry);
+        Gauge.builder("chat.worker.busy", busyWorkers, AtomicInteger::get)
+                .description("Busy chat stream worker count")
+                .register(meterRegistry);
+        Gauge.builder("chat.stream.backlog", streamBacklog, AtomicLong::get)
+                .description("Current Redis Stream backlog size for chat messages")
+                .register(meterRegistry);
+    }
+
+    public void updateWorkerState(int activeWorkerCount, int busyWorkerCount, long backlogSize) {
+        activeWorkers.set(Math.max(0, activeWorkerCount));
+        busyWorkers.set(Math.max(0, busyWorkerCount));
+        streamBacklog.set(Math.max(0L, backlogSize));
+    }
+
+    public void recordAccepted(boolean duplicated) {
+        Counter.builder("chat.message.accepted")
+                .description("Accepted chat user messages")
+                .tag(DUPLICATED, String.valueOf(duplicated))
+                .register(meterRegistry)
+                .increment();
+    }
+
+    public void recordStreamPublished() {
+        Counter.builder("chat.stream.published")
+                .description("Published chat messages to Redis Stream")
+                .register(meterRegistry)
+                .increment();
+    }
+
+    public void recordScaleEvent(String direction) {
+        Counter.builder("chat.worker.scale.events")
+                .description("Chat worker scale up/down events")
+                .tag(DIRECTION, normalizeTag(direction, "unknown"))
+                .register(meterRegistry)
+                .increment();
+    }
+
+    public void recordQueueWait(Long queuedAtEpochMillis) {
+        if (queuedAtEpochMillis == null || queuedAtEpochMillis <= 0L) {
+            return;
+        }
+
+        long elapsedMillis = System.currentTimeMillis() - queuedAtEpochMillis;
+        if (elapsedMillis < 0L) {
+            return;
+        }
+
+        Timer.builder("chat.queue.wait")
+                .description("Time from Redis Stream enqueue to worker processing start")
+                .register(meterRegistry)
+                .record(elapsedMillis, TimeUnit.MILLISECONDS);
+    }
+
+    public void recordProcessingDuration(long startedNanoTime, String outcome) {
+        recordTimer("chat.worker.processing", OUTCOME, normalizeTag(outcome, "unknown"), startedNanoTime);
+    }
+
+    public void recordLlmDuration(String phase, long startedNanoTime) {
+        recordLlmDuration(phase, "success", startedNanoTime);
+    }
+
+    public void recordLlmDuration(String phase, String outcome, long startedNanoTime) {
+        long elapsedNanos = System.nanoTime() - startedNanoTime;
+        if (elapsedNanos < 0L) {
+            return;
+        }
+
+        Timer.builder("chat.llm.duration")
+                .description("LLM call duration by phase and outcome")
+                .tag(PHASE, normalizeTag(phase, "unknown"))
+                .tag(OUTCOME, normalizeTag(outcome, "unknown"))
+                .register(meterRegistry)
+                .record(Duration.ofNanos(elapsedNanos));
+    }
+
+    public void recordLlmCall(String phase, String outcome, String model, Throwable throwable) {
+        Counter.builder("chat.llm.calls")
+                .description("LLM call count by phase, outcome, model, and normalized error type")
+                .tag(PHASE, normalizeTag(phase, "unknown"))
+                .tag(OUTCOME, normalizeTag(outcome, "unknown"))
+                .tag(MODEL, normalizeTag(model, "unknown"))
+                .tag(ERROR_TYPE, classifyError(throwable))
+                .register(meterRegistry)
+                .increment();
+    }
+
+    public void recordWorkerSkipped(String reason) {
+        Counter.builder("chat.worker.skipped")
+                .description("Skipped chat stream records by worker")
+                .tag(REASON, normalizeTag(reason, "unknown"))
+                .register(meterRegistry)
+                .increment();
+    }
+
+    public void recordInterruptRequested() {
+        Counter.builder("chat.interrupt.requested")
+                .description("Requested chat answer interruptions")
+                .register(meterRegistry)
+                .increment();
+    }
+
+    private void recordTimer(String metricName, String tagName, String tagValue, long startedNanoTime) {
+        long elapsedNanos = System.nanoTime() - startedNanoTime;
+        if (elapsedNanos < 0L) {
+            return;
+        }
+
+        Timer.builder(metricName)
+                .tag(tagName, tagValue)
+                .register(meterRegistry)
+                .record(Duration.ofNanos(elapsedNanos));
+    }
+
+    private String classifyError(Throwable throwable) {
+        if (throwable == null) {
+            return "none";
+        }
+
+        Throwable cursor = throwable;
+        while (cursor != null) {
+            if (cursor instanceof LlmQuotaExceededException) {
+                return "quota";
+            }
+
+            String message = cursor.getMessage();
+            if (StringUtils.hasText(message)) {
+                String lower = message.toLowerCase();
+                if (lower.contains("quota") || lower.contains("429") || lower.contains("resource_exhausted")) {
+                    return "quota";
+                }
+                if (lower.contains("timeout") || lower.contains("timed out")) {
+                    return "timeout";
+                }
+                if (lower.contains("rate limit") || lower.contains("too many requests")) {
+                    return "rate_limit";
+                }
+            }
+
+            if (cursor instanceof InterruptedException) {
+                return "interrupted";
+            }
+            cursor = cursor.getCause();
+        }
+
+        return "unknown";
+    }
+
+    private String normalizeTag(String value, String defaultValue) {
+        if (!StringUtils.hasText(value)) {
+            return defaultValue;
+        }
+        return value.trim()
+                .toLowerCase()
+                .replaceAll("[^a-z0-9_.-]", "_");
+    }
+}

--- a/src/main/java/kr/inventory/domain/chat/service/ChatResponseRefinementService.java
+++ b/src/main/java/kr/inventory/domain/chat/service/ChatResponseRefinementService.java
@@ -1,0 +1,63 @@
+package kr.inventory.domain.chat.service;
+
+import kr.inventory.domain.chat.monitoring.ChatMetricsRecorder;
+import kr.inventory.domain.chat.service.context.ChatAnswerPlan;
+import kr.inventory.domain.chat.service.context.ChatConversationContext;
+import kr.inventory.global.llm.dto.LlmChatResponse;
+import kr.inventory.global.llm.service.LlmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatResponseRefinementService {
+
+    private final ChatPromptService chatPromptService;
+    private final ChatAnswerPlanningService chatAnswerPlanningService;
+    private final LlmService llmService;
+    private final ChatMetricsRecorder chatMetricsRecorder;
+
+    public String refineIfNeeded(
+            ChatConversationContext context,
+            ChatAnswerPlan answerPlan,
+            String draftAnswer
+    ) {
+        if (!StringUtils.hasText(draftAnswer)) {
+            return draftAnswer;
+        }
+
+        boolean tooShort = draftAnswer.trim().length() < chatAnswerPlanningService.reviewMinAnswerLength();
+        if (!answerPlan.selfReviewEnabled() && !tooShort) {
+            return draftAnswer;
+        }
+
+        try {
+            long refinementStartedNano = System.nanoTime();
+            LlmChatResponse reviewed = llmService.chat(
+                    "당신은 답변 품질을 높이는 리뷰어입니다. 초안의 사실관계는 바꾸지 말고, 누락된 맥락과 실행 포인트를 보강한 최종 답변만 출력하세요.",
+                    chatPromptService.buildReviewPrompt(context, draftAnswer),
+                    chatAnswerPlanningService.reviewOptions()
+            );
+            chatMetricsRecorder.recordLlmDuration("refinement", refinementStartedNano);
+
+            return StringUtils.hasText(reviewed.text()) ? reviewed.text().trim() : draftAnswer;
+        } catch (Exception e) {
+            log.warn(
+                    "Chat response refinement failed. Returning draft answer. currentUserMessage={}, reason={}",
+                    context != null ? truncate(context.currentUserMessage(), 120) : null,
+                    e.getMessage()
+            );
+            return draftAnswer;
+        }
+    }
+
+    private String truncate(String text, int maxLength) {
+        if (!StringUtils.hasText(text) || text.length() <= maxLength) {
+            return text;
+        }
+        return text.substring(0, maxLength) + "...";
+    }
+}


### PR DESCRIPTION
## 이슈 번호
- Closes #264

## 작업 개요
챗봇 요청 처리 흐름을 운영 관점에서 확인할 수 있도록 Prometheus/Grafana 기반 관측 환경을 구성한다.

Spring Boot Actuator와 Micrometer Prometheus를 연동해 챗봇 요청 수, 응답 성공/실패 수, LLM 호출 실패 유형, 처리 시간, Redis Stream 워커 상태를 메트릭으로 수집하고, Grafana 대시보드에서 확인할 수 있도록 한다.

또한 Grafana datasource/dashboard provisioning을 추가해 컨테이너 재기동 후에도 Prometheus 연동과 챗봇 대시보드가 자동으로 로드되도록 구성한다.

## 작업 내용
- Spring Boot Actuator와 Micrometer Prometheus를 연동해 /actuator/prometheus 기반 애플리케이션 메트릭을 노출한다.
- Prometheus scrape 설정을 추가해 백엔드 애플리케이션 메트릭을 수집할 수 있도록 구성한다.
- 챗봇 요청 수, 응답 성공/실패 수, LLM 호출 성공/실패, quota/rate limit 발생 여부를 커스텀 메트릭으로 기록한다.
- Redis Stream 워커 처리량, 처리 지연, 큐 대기 시간 등 챗봇 비동기 처리 흐름을 관측할 수 있도록 구성한다.
- Grafana datasource provisioning을 추가해 Prometheus datasource가 자동 등록되도록 구성한다.
- Grafana dashboard provisioning을 추가해 컨테이너 재기동 후에도 챗봇 관측 대시보드가 자동 로드되도록 구성한다.
- 챗봇 관측용 Grafana dashboard를 추가해 요청량, 성공/실패 비율, LLM 실패 유형, 처리 시간, 워커 상태를 확인할 수 있도록 한다.
- Grafana provisioning path와 dashboard volume mount 경로를 일치시켜 localhost:3000/dashboards에서 대시보드가 정상 표시되도록 수정한다.

## 완료 조건
- 로컬 실행/기본 동작 확인
- docker compose up -d 실행 후 Prometheus와 Grafana가 정상 기동된다.
- localhost:9090에서 Prometheus에 접속할 수 있다.
- /actuator/prometheus에서 Spring Boot 애플리케이션 메트릭이 노출된다.
- Grafana에서 Prometheus datasource가 자동 등록된다.
- ocalhost:3000/dashboards에서 챗봇 관측 대시보드가 표시된다.
- 챗봇 요청 후 Grafana에서 요청 수, 성공/실패 수, 처리 시간, LLM 실패 유형, Redis Stream 워커 상태를 확인할 수 있다.
- Grafana 컨테이너를 재시작해도 datasource와 dashboard 설정이 유지된다.
